### PR TITLE
Add-SettingScreen

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-07-24T07:27:44.210560Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/hry-23/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,4 +56,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.androidx.navigation.compose)
 }

--- a/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -46,12 +47,20 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {
-                        MyScreen(onNavigateToSettings = {
-                            navController.navigate("settings")
-                        })
+                        MyScreen(
+                            onNavigateToSettings = {
+                            navController.navigate("settings") },
+                            onNavigateToProfile = {
+                        navController.navigate("profile")
+                    })
                     }
                     composable("settings") {
                         SettingsScreen(onNavigateUp = {
+                            navController.popBackStack()
+                        })
+                    }
+                    composable("profile") {
+                        ProfileScreen(onNavigateUp = {
                             navController.popBackStack()
                         })
                     }
@@ -63,29 +72,42 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyScreen(onNavigateToSettings: () -> Unit) { // 設定画面へのナビゲーションコールバックを追加
-    Scaffold(topBar = {
-        TopAppBar(
-            title = { Text("ヘッダー") }, colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = Color(0xFF1976D2), titleContentColor = Color.White
-            ), actions = { // TopAppBarに設定アイコンボタンを追加
-                IconButton(onClick = onNavigateToSettings) {
-                    Icon(
-                        imageVector = Icons.Filled.Settings,
-                        contentDescription = "設定画面へ",
-                        tint = Color.White // アイコンの色を白に指定
-                    )
+fun MyScreen(
+    onNavigateToSettings: () -> Unit,
+    onNavigateToProfile: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Top") },
+                actions = {
+                    IconButton(onClick = onNavigateToProfile) {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            contentDescription = "Profileへ",
+                            tint = Color.Black
+                        )
+                    }
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settingsへ",
+                            tint = Color.Black
+                        )
+                    }
                 }
-            })
-    }, bottomBar = {
-        BottomAppBar(
-            containerColor = Color(0xFF388E3C)
-        ) {
-            Text(
-                "フッター", modifier = Modifier.padding(16.dp), color = Color.White
             )
+        },
+        bottomBar = {
+            BottomAppBar(
+                containerColor = Color(0xFF388E3C)
+            ) {
+                Text(
+                    "フッター", modifier = Modifier.padding(16.dp), color = Color.White
+                )
+            }
         }
-    }) { innerPadding ->
+    ) { innerPadding ->
         Greeting(
             modifier = Modifier.padding(innerPadding)
         )
@@ -193,17 +215,33 @@ fun SettingsScreen(onNavigateUp: () -> Unit) { // メイン画面に戻るため
                 .padding(16.dp) // 内側のコンテンツにさらにパディング
         ) {
             Text("ここに設定項目が表示されます。")
-            // 今後、ここに具体的な設定UI（Switch、TextFieldなど）を追加していきます。
-            // 例:
-            // var notificationsEnabled by remember { mutableStateOf(true) }
-            // Row(verticalAlignment = Alignment.CenterVertically) {
-            //     Text("通知を有効にする")
-            //     Spacer(Modifier.weight(1f))
-            //     Switch(
-            //         checked = notificationsEnabled,
-            //         onCheckedChange = { notificationsEnabled = it }
-            //     )
-            // }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onNavigateUp: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profile") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
+                        )
+                    }
+                }
+            )
+        }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize() // コンテンツが画面全体に広がるように
+                .padding(16.dp) // 内側のコンテンツにさらにパディング
+        ) {
+            Text("ここにProfileが表示されます。")
         }
     }
 }
@@ -214,7 +252,6 @@ fun DefaultPreview() {
     KotlinpracticeTheme {
         // Preview用にNavHostは不要なので、直接MyScreenを呼び出すか、
         // もしSettingsScreenをプレビューしたい場合はSettingsScreenを呼び出す
-        MyScreen(onNavigateToSettings = {})
-// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
+        MyScreen(onNavigateToSettings = {}, onNavigateToProfile = {})// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
     }
 }

--- a/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
@@ -24,8 +24,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 
 
 class MainActivity : ComponentActivity() {
@@ -34,7 +42,20 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             KotlinpracticeTheme {
-                MyScreen()
+                // NavControllerを初期化
+                val navController = rememberNavController()
+                NavHost(navController = navController, startDestination = "main") {
+                    composable("main") {
+                        MyScreen(onNavigateToSettings = {
+                            navController.navigate("settings")
+                        })
+                    }
+                    composable("settings") {
+                        SettingsScreen(onNavigateUp = {
+                            navController.popBackStack()
+                        })
+                    }
+                }
             }
         }
     }
@@ -42,53 +63,58 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyScreen() {
-    Scaffold (
-        topBar = {
-            TopAppBar(
-                title = { Text("ヘッダー") },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color(0xFF1976D2),
-                    titleContentColor = Color.White
-                )
+fun MyScreen(onNavigateToSettings: () -> Unit) { // 設定画面へのナビゲーションコールバックを追加
+    Scaffold(topBar = {
+        TopAppBar(
+            title = { Text("ヘッダー") }, colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color(0xFF1976D2), titleContentColor = Color.White
+            ), actions = { // TopAppBarに設定アイコンボタンを追加
+                IconButton(onClick = onNavigateToSettings) {
+                    Icon(
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = "設定画面へ",
+                        tint = Color.White // アイコンの色を白に指定
+                    )
+                }
+            })
+    }, bottomBar = {
+        BottomAppBar(
+            containerColor = Color(0xFF388E3C)
+        ) {
+            Text(
+                "フッター", modifier = Modifier.padding(16.dp), color = Color.White
             )
-        },
-        bottomBar = {
-            BottomAppBar (
-                containerColor = Color(0xFF388E3C)
-            ) {
-                Text("フッター",
-                    modifier = Modifier.padding(16.dp),
-                    color = Color.White
-                )
-            }
         }
-    ) { innerPadding ->
-        Greeting (
-            name = "Android",
+    }) { innerPadding ->
+        Greeting(
             modifier = Modifier.padding(innerPadding)
         )
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
+fun Greeting(modifier: Modifier = Modifier) {
     var message by remember { mutableStateOf("押すなよ") }
-    var output  by remember { mutableStateOf("") }
-    var text    by remember { mutableStateOf("") }
+    var output by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf("") }
 
     var heightText by remember { mutableStateOf("") }
     var weightText by remember { mutableStateOf("") }
     var bmiResult by remember { mutableStateOf("") }
 
-    Column(modifier = modifier.padding(16.dp)) {
+    Column(
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxSize()
+    ) { // fillMaxSizeを追加してコンテンツが画面全体に広がるように
         Text(text = "こんにちは!", color = Color.Red)
 
         Button(
-            onClick = { Log.d("Button", "onClick")
-                        message = "押すなって言ったやん"
-                        output  = "お前も韓国語を勉強しろ"
-                      },
+            onClick = {
+                Log.d("Button", "onClick")
+                message = "押すなって言ったやん"
+                output = "お前も韓国語を勉強しろ"
+            },
 
             modifier = Modifier.padding(top = 20.dp)
         ) {
@@ -132,12 +158,63 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
                 } else {
                     bmiResult = "正しい数値を入力してください"
                 }
-            },
-            modifier = Modifier.padding(top = 16.dp)
+            }, modifier = Modifier.padding(top = 16.dp)
         ) {
             Text("BMIを計算する")
         }
 
         Text(text = bmiResult, color = Color.Magenta, modifier = Modifier.padding(top = 16.dp))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(onNavigateUp: () -> Unit) { // メイン画面に戻るためのコールバック
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("設定") }, navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
+                        )
+                    }
+                }, colors = TopAppBarDefaults.topAppBarColors( // メイン画面と色を合わせる例
+                    containerColor = Color(0xFF1976D2),
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White
+                )
+            )
+        }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize() // コンテンツが画面全体に広がるように
+                .padding(16.dp) // 内側のコンテンツにさらにパディング
+        ) {
+            Text("ここに設定項目が表示されます。")
+            // 今後、ここに具体的な設定UI（Switch、TextFieldなど）を追加していきます。
+            // 例:
+            // var notificationsEnabled by remember { mutableStateOf(true) }
+            // Row(verticalAlignment = Alignment.CenterVertically) {
+            //     Text("通知を有効にする")
+            //     Spacer(Modifier.weight(1f))
+            //     Switch(
+            //         checked = notificationsEnabled,
+            //         onCheckedChange = { notificationsEnabled = it }
+            //     )
+            // }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    KotlinpracticeTheme {
+        // Preview用にNavHostは不要なので、直接MyScreenを呼び出すか、
+        // もしSettingsScreenをプレビューしたい場合はSettingsScreenを呼び出す
+        MyScreen(onNavigateToSettings = {})
+// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,11 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+navigationCompose = "2.9.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## 概要

本プルリクエストは、Jetpack Navigation Compose を導入し、アプリケーションのメイン画面と設定画面間の基本的な画面遷移機能を実装するものである。これにより、ユーザーはアプリ内の異なるセクション間を移動可能となる。


## やったこと

-   `androidx.navigation:navigation-compose` ライブラリをプロジェクトに追加。
-   バージョンカタログ (`libs.versions.toml`) に上記ライブラリの依存関係定義を追加。
-   メイン画面 (`MyScreen`) のUIを作成。
-   設定画面 (`SettingsScreen`) のUIを作成。
-   `NavHost` を使用し、`MyScreen` と `SettingsScreen` 間のナビゲーションルートを設定。
-   `MyScreen` のトップアプリバーに設定アイコンを配置し、タップで `SettingsScreen` へ遷移するロジックを実装。
-   `SettingsScreen` のトップアプリバーに戻るアイコンを配置し、タップで `MyScreen` へ戻るロジックを実装。
-   非推奨の `Icons.Filled.ArrowBack` を `Icons.AutoMirrored.Filled.ArrowBack` に更新。

## 変更結果

**メイン画面:**
<img src="https://github.com/user-attachments/assets/d0604129-8a5a-4da3-96b9-e08e31d869df" width="300" alt="メイン画面のスクリーンショット。ヘッダーに設定アイコンが見える。" />

*   ヘッダー右上の設定アイコンをタップすると、設定画面へ遷移する。

**設定画面:**
<img src="https://github.com/user-attachments/assets/0376a7cc-7ee3-49f4-bc41-3d504f6252b9" width="300" alt="設定画面のスクリーンショット。ヘッダーに戻るアイコンが見える。" />

*   ヘッダー左上の戻るアイコンをタップすると、メイン画面へ戻る。

## やらないこと

-   設定画面内の具体的な設定項目の実装。
-   複雑な画面遷移（例: 引数を伴う画面遷移、ネストされたナビゲーション）。
-   アニメーションを伴う画面遷移のカスタマイズ。

## 注意事項

-   Android Studio でプロジェクトを開いた際、Gradle Sync が自動的に行われる。もしビルドエラーが発生した場合は、手動で Gradle Sync (`File > Sync Project with Gradle Files`) を実行すること。

## どうやるのか

1.  アプリをビルドして起動する。
2.  メイン画面（"ヘッダー" と表示されている画面）が表示される。
3.  画面右上の設定アイコン（歯車の形）をタップする。
4.  設定画面（"設定" と表示されている画面）に遷移することを確認する。
5.  設定画面左上の戻る矢印アイコンをタップする。
6.  メイン画面に戻ることを確認する。
