### PR TITLE
Task5

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-07-24T07:27:44.210560Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/hry-23/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,4 +56,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.androidx.navigation.compose)
 }

--- a/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -46,12 +47,20 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {
-                        MyScreen(onNavigateToSettings = {
-                            navController.navigate("settings")
-                        })
+                        MyScreen(
+                            onNavigateToSettings = {
+                            navController.navigate("settings") },
+                            onNavigateToProfile = {
+                        navController.navigate("profile")
+                    })
                     }
                     composable("settings") {
                         SettingsScreen(onNavigateUp = {
+                            navController.popBackStack()
+                        })
+                    }
+                    composable("profile") {
+                        ProfileScreen(onNavigateUp = {
                             navController.popBackStack()
                         })
                     }
@@ -63,29 +72,42 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyScreen(onNavigateToSettings: () -> Unit) { // 設定画面へのナビゲーションコールバックを追加
-    Scaffold(topBar = {
-        TopAppBar(
-            title = { Text("ヘッダー") }, colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = Color(0xFF1976D2), titleContentColor = Color.White
-            ), actions = { // TopAppBarに設定アイコンボタンを追加
-                IconButton(onClick = onNavigateToSettings) {
-                    Icon(
-                        imageVector = Icons.Filled.Settings,
-                        contentDescription = "設定画面へ",
-                        tint = Color.White // アイコンの色を白に指定
-                    )
+fun MyScreen(
+    onNavigateToSettings: () -> Unit,
+    onNavigateToProfile: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Top") },
+                actions = {
+                    IconButton(onClick = onNavigateToProfile) {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            contentDescription = "Profileへ",
+                            tint = Color.Black
+                        )
+                    }
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settingsへ",
+                            tint = Color.Black
+                        )
+                    }
                 }
-            })
-    }, bottomBar = {
-        BottomAppBar(
-            containerColor = Color(0xFF388E3C)
-        ) {
-            Text(
-                "フッター", modifier = Modifier.padding(16.dp), color = Color.White
             )
+        },
+        bottomBar = {
+            BottomAppBar(
+                containerColor = Color(0xFF388E3C)
+            ) {
+                Text(
+                    "フッター", modifier = Modifier.padding(16.dp), color = Color.White
+                )
+            }
         }
-    }) { innerPadding ->
+    ) { innerPadding ->
         Greeting(
             modifier = Modifier.padding(innerPadding)
         )
@@ -193,17 +215,33 @@ fun SettingsScreen(onNavigateUp: () -> Unit) { // メイン画面に戻るため
                 .padding(16.dp) // 内側のコンテンツにさらにパディング
         ) {
             Text("ここに設定項目が表示されます。")
-            // 今後、ここに具体的な設定UI（Switch、TextFieldなど）を追加していきます。
-            // 例:
-            // var notificationsEnabled by remember { mutableStateOf(true) }
-            // Row(verticalAlignment = Alignment.CenterVertically) {
-            //     Text("通知を有効にする")
-            //     Spacer(Modifier.weight(1f))
-            //     Switch(
-            //         checked = notificationsEnabled,
-            //         onCheckedChange = { notificationsEnabled = it }
-            //     )
-            // }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onNavigateUp: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profile") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
+                        )
+                    }
+                }
+            )
+        }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize() // コンテンツが画面全体に広がるように
+                .padding(16.dp) // 内側のコンテンツにさらにパディング
+        ) {
+            Text("ここにProfileが表示されます。")
         }
     }
 }
@@ -214,7 +252,6 @@ fun DefaultPreview() {
     KotlinpracticeTheme {
         // Preview用にNavHostは不要なので、直接MyScreenを呼び出すか、
         // もしSettingsScreenをプレビューしたい場合はSettingsScreenを呼び出す
-        MyScreen(onNavigateToSettings = {})
-// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
+        MyScreen(onNavigateToSettings = {}, onNavigateToProfile = {})// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
     }
 }

--- a/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
@@ -4,38 +4,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.example.kotlin_practice.ui.theme.KotlinpracticeTheme
-import androidx.compose.ui.graphics.Color
-import android.util.Log
-import androidx.compose.runtime.remember
-import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.material3.TextField
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Settings
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-
+import com.example.kotlin_practice.ui.theme.KotlinpracticeTheme
+// 他のスクリーンファイルをインポート (実際のパッケージ構造に合わせてください)
+// import com.example.kotlin_practice.ui.screens.MyScreen
+// import com.example.kotlin_practice.ui.screens.SettingsScreen
+// import com.example.kotlin_practice.ui.screens.ProfileScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -43,215 +21,37 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             KotlinpracticeTheme {
-                // NavControllerを初期化
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {
+                        // MyScreenを呼び出し (MyScreen.ktからインポート)
                         MyScreen(
-                            onNavigateToSettings = {
-                            navController.navigate("settings") },
-                            onNavigateToProfile = {
-                        navController.navigate("profile")
-                    })
+                            onNavigateToSettings = { navController.navigate("settings") },
+                            onNavigateToProfile = { navController.navigate("profile") }
+                        )
                     }
                     composable("settings") {
-                        SettingsScreen(onNavigateUp = {
-                            navController.popBackStack()
-                        })
+                        // SettingsScreenを呼び出し (SettingsScreen.ktからインポート)
+                        SettingsScreen(onNavigateUp = { navController.popBackStack() })
                     }
                     composable("profile") {
-                        ProfileScreen(onNavigateUp = {
-                            navController.popBackStack()
-                        })
+                        // ProfileScreenを呼び出し (ProfileScreen.ktからインポート)
+                        ProfileScreen(onNavigateUp = { navController.popBackStack() })
                     }
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun MyScreen(
-    onNavigateToSettings: () -> Unit,
-    onNavigateToProfile: () -> Unit
-) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Top") },
-                actions = {
-                    IconButton(onClick = onNavigateToProfile) {
-                        Icon(
-                            imageVector = Icons.Filled.Person,
-                            contentDescription = "Profileへ",
-                            tint = Color.Black
-                        )
-                    }
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(
-                            imageVector = Icons.Filled.Settings,
-                            contentDescription = "Settingsへ",
-                            tint = Color.Black
-                        )
-                    }
-                }
-            )
-        },
-        bottomBar = {
-            BottomAppBar(
-                containerColor = Color(0xFF388E3C)
-            ) {
-                Text(
-                    "フッター", modifier = Modifier.padding(16.dp), color = Color.White
-                )
-            }
-        }
-    ) { innerPadding ->
-        Greeting(
-            modifier = Modifier.padding(innerPadding)
-        )
-    }
-}
-
-@Composable
-fun Greeting(modifier: Modifier = Modifier) {
-    var message by remember { mutableStateOf("押すなよ") }
-    var output by remember { mutableStateOf("") }
-    var text by remember { mutableStateOf("") }
-
-    var heightText by remember { mutableStateOf("") }
-    var weightText by remember { mutableStateOf("") }
-    var bmiResult by remember { mutableStateOf("") }
-
-    Column(
-        modifier = modifier
-            .padding(16.dp)
-            .fillMaxSize()
-    ) { // fillMaxSizeを追加してコンテンツが画面全体に広がるように
-        Text(text = "こんにちは!", color = Color.Red)
-
-        Button(
-            onClick = {
-                Log.d("Button", "onClick")
-                message = "押すなって言ったやん"
-                output = "お前も韓国語を勉強しろ"
-            },
-
-            modifier = Modifier.padding(top = 20.dp)
-        ) {
-            Text(message)
-        }
-        Text(text = output, color = Color.Blue)
-
-        TextField(
-            value = text,
-            onValueChange = { text = it },
-            label = { Text("自由入力") },
-            modifier = Modifier.padding(top = 20.dp)
-        )
-
-        // BMI計算用のUI
-        Text(text = "BMI計算", color = Color.Black, modifier = Modifier.padding(top = 30.dp))
-
-        TextField(
-            value = heightText,
-            onValueChange = { heightText = it },
-            label = { Text("身長 (cm)") },
-            modifier = Modifier.padding(top = 8.dp)
-        )
-
-        TextField(
-            value = weightText,
-            onValueChange = { weightText = it },
-            label = { Text("体重 (kg)") },
-            modifier = Modifier.padding(top = 8.dp)
-        )
-
-        Button(
-            onClick = {
-                val height = heightText.toFloatOrNull()
-                val weight = weightText.toFloatOrNull()
-
-                if (height != null && weight != null && height > 0) {
-                    val heightInMeters = height / 100
-                    val bmi = weight / (heightInMeters * heightInMeters)
-                    bmiResult = "あなたのBMIは %.2f です".format(bmi)
-                } else {
-                    bmiResult = "正しい数値を入力してください"
-                }
-            }, modifier = Modifier.padding(top = 16.dp)
-        ) {
-            Text("BMIを計算する")
-        }
-
-        Text(text = bmiResult, color = Color.Magenta, modifier = Modifier.padding(top = 16.dp))
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun SettingsScreen(onNavigateUp: () -> Unit) { // メイン画面に戻るためのコールバック
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("設定") }, navigationIcon = {
-                    IconButton(onClick = onNavigateUp) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
-                        )
-                    }
-                }, colors = TopAppBarDefaults.topAppBarColors( // メイン画面と色を合わせる例
-                    containerColor = Color(0xFF1976D2),
-                    titleContentColor = Color.White,
-                    navigationIconContentColor = Color.White
-                )
-            )
-        }) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize() // コンテンツが画面全体に広がるように
-                .padding(16.dp) // 内側のコンテンツにさらにパディング
-        ) {
-            Text("ここに設定項目が表示されます。")
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ProfileScreen(onNavigateUp: () -> Unit) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Profile") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateUp) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
-                        )
-                    }
-                }
-            )
-        }) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize() // コンテンツが画面全体に広がるように
-                .padding(16.dp) // 内側のコンテンツにさらにパディング
-        ) {
-            Text("ここにProfileが表示されます。")
         }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun DefaultPreview() {
+fun DefaultAppPreview() { // Preview関数名を変更して、アプリ全体を示すようにする
     KotlinpracticeTheme {
-        // Preview用にNavHostは不要なので、直接MyScreenを呼び出すか、
-        // もしSettingsScreenをプレビューしたい場合はSettingsScreenを呼び出す
-        MyScreen(onNavigateToSettings = {}, onNavigateToProfile = {})// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
+        // ナビゲーションを含むアプリ全体のプレビューは複雑になることがあるため、
+        // ここでは特定の初期画面（例: MyScreen）をプレビューする形にするか、
+        // NavHostを使ったプレビューのヘルパー関数を別途用意することを検討します。
+        // 簡単のため、MyScreenを直接プレビューします。
+        MyScreen(onNavigateToSettings = {}, onNavigateToProfile = {})
     }
 }

--- a/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlin_practice/MainActivity.kt
@@ -24,8 +24,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 
 
 class MainActivity : ComponentActivity() {
@@ -34,7 +42,20 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             KotlinpracticeTheme {
-                MyScreen()
+                // NavControllerを初期化
+                val navController = rememberNavController()
+                NavHost(navController = navController, startDestination = "main") {
+                    composable("main") {
+                        MyScreen(onNavigateToSettings = {
+                            navController.navigate("settings")
+                        })
+                    }
+                    composable("settings") {
+                        SettingsScreen(onNavigateUp = {
+                            navController.popBackStack()
+                        })
+                    }
+                }
             }
         }
     }
@@ -42,53 +63,58 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyScreen() {
-    Scaffold (
-        topBar = {
-            TopAppBar(
-                title = { Text("ヘッダー") },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color(0xFF1976D2),
-                    titleContentColor = Color.White
-                )
+fun MyScreen(onNavigateToSettings: () -> Unit) { // 設定画面へのナビゲーションコールバックを追加
+    Scaffold(topBar = {
+        TopAppBar(
+            title = { Text("ヘッダー") }, colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = Color(0xFF1976D2), titleContentColor = Color.White
+            ), actions = { // TopAppBarに設定アイコンボタンを追加
+                IconButton(onClick = onNavigateToSettings) {
+                    Icon(
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = "設定画面へ",
+                        tint = Color.White // アイコンの色を白に指定
+                    )
+                }
+            })
+    }, bottomBar = {
+        BottomAppBar(
+            containerColor = Color(0xFF388E3C)
+        ) {
+            Text(
+                "フッター", modifier = Modifier.padding(16.dp), color = Color.White
             )
-        },
-        bottomBar = {
-            BottomAppBar (
-                containerColor = Color(0xFF388E3C)
-            ) {
-                Text("フッター",
-                    modifier = Modifier.padding(16.dp),
-                    color = Color.White
-                )
-            }
         }
-    ) { innerPadding ->
-        Greeting (
-            name = "Android",
+    }) { innerPadding ->
+        Greeting(
             modifier = Modifier.padding(innerPadding)
         )
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
+fun Greeting(modifier: Modifier = Modifier) {
     var message by remember { mutableStateOf("押すなよ") }
-    var output  by remember { mutableStateOf("") }
-    var text    by remember { mutableStateOf("") }
+    var output by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf("") }
 
     var heightText by remember { mutableStateOf("") }
     var weightText by remember { mutableStateOf("") }
     var bmiResult by remember { mutableStateOf("") }
 
-    Column(modifier = modifier.padding(16.dp)) {
+    Column(
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxSize()
+    ) { // fillMaxSizeを追加してコンテンツが画面全体に広がるように
         Text(text = "こんにちは!", color = Color.Red)
 
         Button(
-            onClick = { Log.d("Button", "onClick")
-                        message = "押すなって言ったやん"
-                        output  = "お前も韓国語を勉強しろ"
-                      },
+            onClick = {
+                Log.d("Button", "onClick")
+                message = "押すなって言ったやん"
+                output = "お前も韓国語を勉強しろ"
+            },
 
             modifier = Modifier.padding(top = 20.dp)
         ) {
@@ -132,12 +158,63 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
                 } else {
                     bmiResult = "正しい数値を入力してください"
                 }
-            },
-            modifier = Modifier.padding(top = 16.dp)
+            }, modifier = Modifier.padding(top = 16.dp)
         ) {
             Text("BMIを計算する")
         }
 
         Text(text = bmiResult, color = Color.Magenta, modifier = Modifier.padding(top = 16.dp))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(onNavigateUp: () -> Unit) { // メイン画面に戻るためのコールバック
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("設定") }, navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "戻る"
+                        )
+                    }
+                }, colors = TopAppBarDefaults.topAppBarColors( // メイン画面と色を合わせる例
+                    containerColor = Color(0xFF1976D2),
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White
+                )
+            )
+        }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize() // コンテンツが画面全体に広がるように
+                .padding(16.dp) // 内側のコンテンツにさらにパディング
+        ) {
+            Text("ここに設定項目が表示されます。")
+            // 今後、ここに具体的な設定UI（Switch、TextFieldなど）を追加していきます。
+            // 例:
+            // var notificationsEnabled by remember { mutableStateOf(true) }
+            // Row(verticalAlignment = Alignment.CenterVertically) {
+            //     Text("通知を有効にする")
+            //     Spacer(Modifier.weight(1f))
+            //     Switch(
+            //         checked = notificationsEnabled,
+            //         onCheckedChange = { notificationsEnabled = it }
+            //     )
+            // }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    KotlinpracticeTheme {
+        // Preview用にNavHostは不要なので、直接MyScreenを呼び出すか、
+        // もしSettingsScreenをプレビューしたい場合はSettingsScreenを呼び出す
+        MyScreen(onNavigateToSettings = {})
+// SettingsScreen(onNavigateUp = {}) // SettingsScreenをプレビュー
     }
 }

--- a/app/src/main/java/com/example/kotlin_practice/ui/theme/MyScreen.kt
+++ b/app/src/main/java/com/example/kotlin_practice/ui/theme/MyScreen.kt
@@ -1,0 +1,153 @@
+package com.example.kotlin_practice // または com.example.kotlin_practice.ui.screens など
+
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.kotlin_practice.ui.theme.KotlinpracticeTheme // Themeのインポートがここでも必要になる場合がある (Preview用)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyScreen(
+    onNavigateToSettings: () -> Unit,
+    onNavigateToProfile: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Top") },
+                actions = {
+                    IconButton(onClick = onNavigateToProfile) {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            contentDescription = "Profileへ",
+                            tint = Color.Black
+                        )
+                    }
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settingsへ",
+                            tint = Color.Black
+                        )
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            BottomAppBar(
+                containerColor = Color(0xFF388E3C)
+            ) {
+                Text(
+                    "フッター", modifier = Modifier.padding(16.dp), color = Color.White
+                )
+            }
+        }
+    ) { innerPadding ->
+        Greeting( // Greeting関数をMyScreen内で呼び出し
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Composable
+fun Greeting(modifier: Modifier = Modifier) {
+    var message by remember { mutableStateOf("押すなよ") }
+    var output by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf("") }
+
+    var heightText by remember { mutableStateOf("") }
+    var weightText by remember { mutableStateOf("") }
+    var bmiResult by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .padding(16.dp) // この画面固有の追加padding
+            .fillMaxSize()
+    ) {
+        Text(text = "こんにちは!", color = Color.Red)
+
+        Button(
+            onClick = {
+                Log.d("Button", "onClick")
+                message = "押すなって言ったやん"
+                output = "お前も韓国語を勉強しろ"
+            },
+            modifier = Modifier.padding(top = 20.dp)
+        ) {
+            Text(message)
+        }
+        Text(text = output, color = Color.Blue)
+
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            label = { Text("自由入力") },
+            modifier = Modifier.padding(top = 20.dp)
+        )
+
+        Text(text = "BMI計算", color = Color.Black, modifier = Modifier.padding(top = 30.dp))
+
+        TextField(
+            value = heightText,
+            onValueChange = { heightText = it },
+            label = { Text("身長 (cm)") },
+            modifier = Modifier.padding(top = 8.dp)
+        )
+
+        TextField(
+            value = weightText,
+            onValueChange = { weightText = it },
+            label = { Text("体重 (kg)") },
+            modifier = Modifier.padding(top = 8.dp)
+        )
+
+        Button(
+            onClick = {
+                val height = heightText.toFloatOrNull()
+                val weight = weightText.toFloatOrNull()
+
+                if (height != null && weight != null && height > 0) {
+                    val heightInMeters = height / 100
+                    val bmi = weight / (heightInMeters * heightInMeters)
+                    bmiResult = "あなたのBMIは %.2f です".format(bmi)
+                } else {
+                    bmiResult = "正しい数値を入力してください"
+                }
+            }, modifier = Modifier.padding(top = 16.dp)
+        ) {
+            Text("BMIを計算する")
+        }
+
+        Text(text = bmiResult, color = Color.Magenta, modifier = Modifier.padding(top = 16.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MyScreenPreview() {
+    KotlinpracticeTheme {
+        MyScreen(onNavigateToSettings = {}, onNavigateToProfile = {})
+    }
+}

--- a/app/src/main/java/com/example/kotlin_practice/ui/theme/ProfileScreen.kt
+++ b/app/src/main/java/com/example/kotlin_practice/ui/theme/ProfileScreen.kt
@@ -1,0 +1,65 @@
+package com.example.kotlin_practice // または com.example.kotlin_practice.ui.screens など
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.kotlin_practice.ui.theme.KotlinpracticeTheme // Themeのインポート
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    onNavigateUp: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("プロフィール") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color(0xFFC2185B), // 元のコードの色を維持 (ProfileScreen用の色に注意)
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .padding(16.dp) // この画面固有の追加padding
+        ) {
+            Text("ユーザーのプロフィール情報がここに表示されます。")
+            // 必要であれば、他のプロフィール関連のUI要素をここに追加します。
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProfileScreenPreview() {
+    KotlinpracticeTheme {
+        ProfileScreen(onNavigateUp = {})
+    }
+}

--- a/app/src/main/java/com/example/kotlin_practice/ui/theme/SettingsScreen.kt
+++ b/app/src/main/java/com/example/kotlin_practice/ui/theme/SettingsScreen.kt
@@ -1,0 +1,65 @@
+package com.example.kotlin_practice // または com.example.kotlin_practice.ui.screens など
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.kotlin_practice.ui.theme.KotlinpracticeTheme // Themeのインポート
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    onNavigateUp: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("設定") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "戻る"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color(0xFF1976D2),
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .padding(16.dp) // この画面固有の追加padding
+        ) {
+            Text("ここに設定項目が表示されます。")
+            // 必要であれば、他の設定関連のUI要素をここに追加します。
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    KotlinpracticeTheme {
+        SettingsScreen(onNavigateUp = {})
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,11 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+navigationCompose = "2.9.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
# 画面遷移の抽出と各画面ファイル分割

## 概要
Jetpack Navigation Compose を導入し、MainActivity から UI ロジックを分離。Top/Settings/Profile の各画面を個別ファイル (MyScreen.kt / SettingsScreen.kt / ProfileScreen.kt) に切り出して、明確な画面遷移構成にした。

## 原因と対処法（バグ修正の場合）
- 原因: MainActivity に UI と画面遷移が混在しており、可読性・テスト容易性が低い構造だった。
- 対処: Navigation Compose を導入して NavHost を MainActivity に配置し、各画面は Composable を別ファイル化。イベントハンドラ（画面遷移コールバック）を引数で渡す構造に変更。

## やったこと
- MyScreen.kt を新規作成
- SettingsScreen.kt を新規作成
- ProfileScreen.kt を新規作成
- 
## 変更結果
- 画面遷移動作

## やらないこと
- デザインの大幅変更（テーマ、配色、レイアウトの刷新）
- 画面状態の永続化（ViewModel/State 保存）
- 深いナビゲーション（引数付き遷移、Nested NavGraph）
- テストコードの追加

## 注意事項
- マージ後にクリーンビルドを推奨
  - Android Studio: Invalidate Caches / Restart（必要に応じて）
  - Gradle 同期を実行
- navigation-compose のバージョンは libs.versions.toml で管理（2.9.2）

## 課題
- 画面間で共有する状態（例: ユーザープロフィール）の管理方式を検討（ViewModel + SavedStateHandle）
- ルート名の定数化・NavGraph の分割（複雑化に備えて）
- UI 文言の見直し（国際化対応や不適切表現の削除を含む）
  - 現在のメッセージに不適切な表現が含まれるため、次回修正で削除・改善したい

## 備考
- 変更ファイル
  - MainActivity.kt: 大幅リファクタ（NavHost 設置・UI 切り出し）
  - MyScreen.kt: 新規（Top 画面 + Greeting/BMI）
  - SettingsScreen.kt: 新規
  - ProfileScreen.kt: 新規
  - build.gradle.kts: 依存追加
  - libs.versions.toml: ライブラリ登録
- 参考: Jetpack Navigation Compose の公式ドキュメント（社内ナレッジ/既存プロジェクト構成に準拠）
